### PR TITLE
1.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.unity-packages.nuget-for-unity",
   "displayName": "NuGet For Unity",
   "description": "Unity Editor support for finding, installing, and managing NuGet packages.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "unity": "2019.1",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Make sure we don't import dlls that are already supported in packages that have a Unity folder. This is a side effect of supporting more generic NuGet packages while some packages were built for the initial version of NuGet for Unity.